### PR TITLE
fixed bug for article status ,by category

### DIFF
--- a/wwwroot/Application/Admin/Model/DocumentModel.class.php
+++ b/wwwroot/Application/Admin/Model/DocumentModel.class.php
@@ -269,7 +269,7 @@ class DocumentModel extends Model{
     	$id = I('post.id');
         $cate = I('post.category_id');
         if(empty($id)){	//新增
-        	$status = 1;
+        	$status = D('Category')->getFieldById($cate, 'check') ? 2 : 1;
         }else{				//更新
 			$status = $this->getFieldById($id, 'status');
 			//编辑草稿改变状态


### PR DESCRIPTION
在Application/Admin/Model/DocumentModel.class.php中的getStatus尚未完全实现。理由：分类模块中给出了一个是否需要审核的参数，那么此处应该应从分类模型中获取此参数。以生效该分类配置。
