### PR TITLE
Update base.html

### DIFF
--- a/wwwroot/Application/Admin/View/Public/base.html
+++ b/wwwroot/Application/Admin/View/Public/base.html
@@ -140,8 +140,7 @@
             $("#subnav").on("click", "h3", function(){
                 var $this = $(this);
                 $this.find(".icon").toggleClass("icon-fold");
-                $this.next().slideToggle("fast").siblings(".side-sub-menu:visible").
-                      prev("h3").find("i").addClass("icon-fold").end().end().hide();
+                $this.next().slideToggle("fast").siblings(".side-sub-menu:visible");
             });
 
             $("#subnav h3 a").click(function(e){e.stopPropagation()});


### PR DESCRIPTION
在一个菜单没有分组并且不是隐藏的情况下，在刚进入页面的时，这个菜单是显示的，但是点击了任何一个分组，这个菜单都会隐藏，但是再次点击也不会出现，发现菜单遍历时：
<notempty name="key"><h3><i class="icon icon-unfold"></i>{$key}</h3></notempty>
                        <ul class="side-sub-menu">
                            <volist name="sub_menu" id="menu">
                                <li>
                                    <a class="item" href="{$menu.url|U}">{$menu.title}</a>
                                </li>
                            </volist>
                        </ul>
所以key是空的，所以js隐藏的时候不会显示了；想到解决方法，
1 </notempty>放到</ul>后面，所以没的分组的菜单直接不显示
2 JS 左边菜单显示收起 ，只收起展开当前点击分组
我选择了第二种，
1 菜单的隐藏后台有字段控制，既然选择显示，就不应该没的分组而隐藏
2 点击任何一个分组隐藏其他分组，个人感觉本来就不合理；如果隐藏其他分组是防止菜单过多，看不到全部，那为什么进页面的时候就都展开

小问题，但作为一个开源产品，一起完善，不知道官方有没有好的想法
