### PR TITLE
将基础文档扩充为所有顶级model

### DIFF
--- a/wwwroot/Application/Admin/View/Model/add.html
+++ b/wwwroot/Application/Admin/View/Model/add.html
@@ -29,7 +29,9 @@
 						<div class="controls">
 							<select name="extend">
 								<option value="0">独立模型</option>
-								<option value="1">文档模型</option>
+								<volist name=":get_top_model()" id="list">
+								     <option value="{$list.id}">{$list.title}</option>
+								</volist>
 							</select>
 						</div>
 					</div>


### PR DESCRIPTION
将基础文档扩充为所有顶级model,方便其他model的建立，如商品模型
