### PR TITLE
后台模型增改查（Admin/Think）中添加int型外键和string型外键的支持。

### DIFF
--- a/wwwroot/Application/Admin/Common/function.php
+++ b/wwwroot/Application/Admin/Common/function.php
@@ -144,6 +144,10 @@ function get_attribute_type($type=''){
         'editor'    =>  array('编辑器','text NOT NULL'),
         'picture'   =>  array('上传图片','int(10) UNSIGNED NOT NULL'),
         'file'      =>  array('上传附件','int(10) UNSIGNED NOT NULL'),
+        //foreign_int/foreign_string 2016-06-14 start
+        'foreign_int'     =>  array('int型外键','int(10) UNSIGNED NOT NULL'),
+        'foreign_string'  =>  array('string型下拉列表','varchar(255) UNSIGNED NOT NULL'),
+        //foreign_int/foreign_string 2016-06-14 end
     );
     return $type?$_type[$type][0]:$_type;
 }

--- a/wwwroot/Application/Admin/View/Think/add.html
+++ b/wwwroot/Application/Admin/View/Think/add.html
@@ -55,6 +55,13 @@
                                     </volist>
                                 </select>
                             </case>
+                            <case value="foreign_int|foreign_string">
+                                <select id="{$field.name}" name="{$field.name}">
+                                    <volist name="field['foreign']" id="vo">
+                                        <option value="{$key}" <eq name="data[$field['name']]" value="$key">selected</eq>>{$vo}</option>
+                                    </volist>
+                                </select>
+                            </case>
                             <case value="radio">
                                 <volist name=":parse_field_attr($field['extra'])" id="vo">
                                 	<label class="radio">

--- a/wwwroot/Application/Admin/View/Think/edit.html
+++ b/wwwroot/Application/Admin/View/Think/edit.html
@@ -55,6 +55,13 @@
                                     </volist>
                                 </select>
                             </case>
+                            <case value="foreign_int|foreign_string">
+                                <select id="{$field.name}" name="{$field.name}">
+                                    <volist name="field['foreign']" id="vo">
+                                        <option value="{$key}" <eq name="data[$field['name']]" value="$key">selected</eq>>{$vo}</option>
+                                    </volist>
+                                </select>
+                            </case>
                             <case value="radio">
                                 <volist name=":parse_field_attr($field['extra'])" id="vo">
                                 	<label class="radio">


### PR DESCRIPTION
使用方法：在外键字段属性编辑页中，将“字段类型”选择为“int型外键”，然后在参数框中填入

<pre>
table:your_table_name
key:key_column_name
value:value_column_name
</pre>


以document表的category_id字段为例，参数框中填写：

<pre>
table:category
key:id
value:title
</pre>
